### PR TITLE
Fix dirName change type void* to char*

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
         strcpy(sdcDir,sdcFile);
         sdcDir = dirname(sdcDir);
 
-        print_status("Creating directory structure at '%s'", dirName);
+        print_status("Creating directory structure at '%s'", (char*)dirName);
 
         //create directory according to header
         char *outFile = (char*)malloc(strlen(sdcDir)+strlen((char*)dirName)+2);


### PR DESCRIPTION
Fix dirName void* to char*

Error :
`In file included from main.h:3:0,
                 from main.c:1:
xsdc.h:18:41: attention : format « %s » expects argument of type « char * », but argument 2 has type « void * » [-Wformat=]
 #define print_status(fmt, ...) { printf(" [      ] "fmt"\r", ##__VA_ARGS__); fflush(stdout); }
                                         ^
main.c:229:9: note : in expansion of macro « print_status »
         print_status("Creating directory structure at '%s'", dirName);`