### PR TITLE
Fix perror argument File* to char*

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
             {
                 //error opening a file
                 print_fail();
-                perror(hdrout);
+                perror(optarg);
                 return errno;
             }
             print_ok();


### PR DESCRIPTION
For fix warning to perror required char* argument

Error :
```
main.c:33:24: attention : passing argument 1 of « perror » from incompatible pointer type [-Wincompatible-pointer-types]
                 perror(hdrout);
                        ^~~~~~
In file included from xsdc.h:5:0,
                 from main.h:3,
                 from main.c:1:
/usr/include/stdio.h:848:13: note : expected « const char * » but argument is of type « FILE * {alias struct _IO_FILE *} »
 extern void perror (const char *__s);
             ^~~~~~
```